### PR TITLE
Read framework version from workbook filename

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -10,7 +10,7 @@ To update the `terms.json`:
 
 - Navigate to the `framework` folder in the repo
 - `pip install -r ./requirements.txt`
-- Open `make_json.py` and update the version number to your new version
+- Ensure the framework workbook filename uses the `LLMevalmonitorframework_v<version>.xlsx` format
 - `python make_json.py`
 - Check to see if you need to prettify `terms.json` for human readability (for example, the [Prettify JSON VS Code extension](https://marketplace.visualstudio.com/items?itemName=mohsen1.prettify-json) can be useful here)
 - Update the framework [`CHANGELOG.md`](./CHANGELOG.md) to reflect your updates

--- a/framework/make_json.py
+++ b/framework/make_json.py
@@ -1,8 +1,28 @@
 import pandas as pd
 import json
 from datetime import datetime
+from pathlib import Path
+import re
 
-version="0.2.2"
+FRAMEWORK_PATTERN = "LLMevalmonitorframework_v*.xlsx"
+FRAMEWORK_VERSION_RE = re.compile(r"LLMevalmonitorframework_v(?P<version>.+)\.xlsx$")
+
+
+def framework_version_key(path):
+    return tuple(int(part) for part in FRAMEWORK_VERSION_RE.match(path.name)["version"].split("."))
+
+
+def get_framework_workbook():
+    workbooks = sorted(Path(".").glob(FRAMEWORK_PATTERN), key=framework_version_key)
+    if not workbooks:
+        raise FileNotFoundError(f"No framework workbook found matching {FRAMEWORK_PATTERN}")
+
+    workbook = workbooks[-1]
+    version = FRAMEWORK_VERSION_RE.match(workbook.name)["version"]
+    return workbook, version
+
+
+framework_location, version = get_framework_workbook()
 
 upper_column_name_map = {
     "Meta": "Meta",
@@ -30,9 +50,6 @@ group_map = {
     "Quantifiable Changes": "qc",
 }
 
-
-
-framework_location = f"./LLMevalmonitorframework_v{version}.xlsx"
 terms_output_location = "../data/terms.json"
 
 df = pd.read_excel(


### PR DESCRIPTION
## Summary
- Replaces the hardcoded framework version in `framework/make_json.py` with discovery from `LLMevalmonitorframework_v<version>.xlsx`.
- Uses the discovered workbook path and version when generating `terms.json`.
- Updates the framework README so future updates only need the workbook filename to follow the existing versioned naming convention.

Closes #10.

## Verification
- `python make_json.py` from `framework` -> `JSON file written to ../data/terms.json with 30 terms.`
- `python -m compileall framework\make_json.py tests\validate_json.py`
- `git diff --cached --check`

## AANA gate
- `code_change_review`: pass
- Recommended action: accept
- AIx score: 1.0
- Violations: none
